### PR TITLE
Maintain vim-z80

### DIFF
--- a/ftdetect/z80.vim
+++ b/ftdetect/z80.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.asm set filetype=z80
+autocmd BufNewFile,BufRead *.z80 set filetype=z80

--- a/ftplugin/z80.vim
+++ b/ftplugin/z80.vim
@@ -10,10 +10,10 @@ setlocal shiftwidth=8
 setlocal foldmethod=marker
 setlocal commentstring=;;%s
 
-function! b:IndentLabel()
+function! s:IndentLabel()
     let saved_unnamed_register = @@
 
-    if getline('.') =~ "^\s*[a-zA-Z0-9_.]+:$" then
+    if getline('.') =~ "^\s*[a-zA-Z0-9_.]+:$"
         echom "ok"
         normal! V:s/\s+//g
     endif

--- a/ftplugin/z80.vim
+++ b/ftplugin/z80.vim
@@ -21,4 +21,4 @@ function! s:IndentLabel()
     let @@ = saved_unnamed_register
 endfunction
 
-inoremap <buffer> :normal! all b:IndentLabel()
+inoremap <buffer> :normal! all s:IndentLabel()


### PR DESCRIPTION
File extension matches ubiquitous .z80 ending.
ftplugin/z80.vim changes corrects modern vim syntax errors.