### PR TITLE
Added .gen extension for HiSoft GEN80 assembler

### DIFF
--- a/ftdetect/z80.vim
+++ b/ftdetect/z80.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead *.z80 set filetype=z80
+autocmd BufNewFile,BufRead *.gen set filetype=z80


### PR DESCRIPTION
Thank you for your wonderful z80 syntax highlighting pack. It's an absolute pleasure to use!

I have added ***.gen** extension for HiSoft GEN80 Assembler. The extension is reasonably unique, so it should not get in the way.

#### Some info on GEN80 and Devpac80
- https://www.msx.org/wiki/HiSoft_Development_Pack_80
- https://cpcrulez.fr/applications_coding-hisoft-devpac80.htm
